### PR TITLE
merged inline and factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Style Guide for writing clean and readable CJSX
 * [Complex renders](#complex-renders)
 * [Significant whitespace](#significant-whitespace)
 * [Don't inline methods](#dont-inline-methods)
+* [Usage of method factories for handlers](#usage-of-method-factories-for-handlers)
 * [Usage of quotes in CJSX elements](#usage-of-quotes-in-cjsx-elements)
 
 ## Source Code Layout

--- a/README.md
+++ b/README.md
@@ -236,24 +236,40 @@ Define methods on the component instead of inlining them.
     <a onClick={=> #implementation} />
 ```
 
-Advanced usage, methods with arguments: Since Coffeescript will call the method on render when a argument is passed, the handler method should return the actual method to be called. Use the `-> =>` for this.
-```Coffee
- # Good
-  handleClick: (button_name) -> =>
-    @setState lastButtonClicked: button_name
+Advanced usage, methods with arguments: Since Coffeescript will call the method on render when arguments are passed, the handler method should return the actual method to be called. Use a method factory for this.
 
-  render: ->
-    <a onClick={@handleClick('first')} />
-    <a onClick={@handleClick('second')} />
+## Usage of method factories for handlers
+Often times in CJSX/CoffeeScript you're in need of methods that return methods. We call these methods factories. To be clear about the purpose of the method, it is required to always add the `Factory` postfix to these method names.
+
+The first arrow should always be a -> (for all methods on a component React binds the current component to `@`), but the second one can vary based on the context you need. If you need to call @ in your method, please make sure to use a fat (=>) arrow. Otherwise a -> would suffice.
+
+```Coffee
+  # Good
+  <a onClick={@handleClickFactory('first')} />
+
+  handleClickFactory: (element) -> =>
+    @setState clicked: element
+
+  # Good
+  <a onClick={@handleClickFactory('first')} />
+
+  handleClickFactory: (element) -> ->
+    alert(element)
 
   # Bad
-  handleClick: (button_name) =>
-    @setState lastButtonClicked: button_name
+  <a onClick={@handleClick('first')} />
 
-  render: ->
-    <a onClick={-> @handleClick('first')} />
-    <a onClick={-> @handleClick('second')} />
+  handleClick: (element) -> ->
+    alert(element)
+
+  # Bad
+  <a onClick={-> @handleClick('first')} />
+
+  handleClick: (element) ->
+    @setState clicked: element
+
 ```
+
 ## Usage of quotes in CJSX elements
 Use double quotes instead of single quotes when writing CJSX elements:
 
@@ -268,28 +284,4 @@ Use double quotes instead of single quotes when writing CJSX elements:
 ```
 
 It's fine to use single quotes on non-CJSX elements
-
-## Usage of method factories for handlers
-Often times in CJSX/CoffeeScript you're in need of methods that return methods. We call these methods factories. To be clear about the purpose of the method, it is required to always add the `Factory` postfix to these method names.
-
-The first arrow should always be a -> (for all methods on a component React binds the current component to `@`), but the second one can vary based on the context you need. If you need to call @ in your method, please make sure to use a fat (=>) arrow. Otherwise a -> would suffice.
-Use a method with the postfix `Factory`, use the appropriate arrow.
-
-```Coffee
-  renderItems: ->
-    for element in @props.elements
-      <a className={element.url()} onClick={@togglePopoverFactory(element)} />
-
-  # Good
-  togglePopoverFactory: (element) -> =>
-    @setState popover: element
-
-  # Good
-  togglePopoverFactory: (element) -> ->
-    element.toggleVisibility()
-
-  # Bad
-  togglePopover: (element) -> =>
-    element.toggleVisibility()
-```
 


### PR DESCRIPTION
We had two sections, one about inlining and one about factories, with slightly contradictory statements (first had no `factory` postfix, etc). Moved the two sections closer together, merged some of the examples